### PR TITLE
update metasploit to 4.13.15, use ruby-2.3 and ruby2.3-bundler

### DIFF
--- a/metasploit/PKGBUILD
+++ b/metasploit/PKGBUILD
@@ -3,27 +3,27 @@
 # Contributor: Tobias Veit - nIcE <m.on.key.tobi[at]gmail[dot]com>
 
 pkgname=metasploit
-pkgver=4.13.12
+pkgver=4.13.15
 pkgrel=1
 pkgdesc='Advanced open-source platform for developing, testing, and using exploit code'
 url='https://www.metasploit.com/'
 arch=('i686' 'x86_64')
 license=('BSD')
-depends=('ruby' 'libpcap' 'postgresql-libs' 'ruby-bundler' 'sqlite' 'libxslt' 'git')
+depends=('ruby2.3' 'libpcap' 'postgresql-libs' 'ruby2.3-bundler' 'sqlite' 'libxslt' 'git')
 optdepends=('ruby-pg: database support')
 options=('!strip' '!emptydirs')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/rapid7/metasploit-framework/archive/${pkgver}.tar.gz)
-sha512sums=('da986f3d8cec927d23cb198fcbc5cf1fb865d6924a3c6eefc72246fefdd68c84e92b80de4b719f5d7fe790f32ab45e1cfdc3763466df6a308e776efc9ed98475')
+sha512sums=('fdb2ded9b6ca94fc2644e233cd3adb950f5444e001039b9038aee32d19c38a8314112c7fb3c0da398537d168bfaf71cccdf36f27272283e38209ff0ea27866b4')
 
 prepare() {
   cd ${pkgname}-framework-${pkgver}
-  bundle config build.nokogiri --use-system-libraries
+  bundle-2.3 config build.nokogiri --use-system-libraries
   sed 's|git ls-files|find -type f|' -i metasploit-framework.gemspec
 }
 
 build() {
   cd ${pkgname}-framework-${pkgver}
-  bundle install -j"$(nproc)" --no-cache --deployment
+  bundle-2.3 install -j"$(nproc)" --no-cache --deployment
   find vendor/bundle/ruby -exec chmod o+r '{}' \;
 }
 
@@ -35,14 +35,14 @@ package() {
 
   for f in "${pkgdir}"/opt/${pkgname}/msf*; do
     local _msffile="${pkgdir}/usr/bin/`basename "${f}"`"
-    echo -e "#!/bin/sh\nBUNDLE_GEMFILE=/opt/${pkgname}/Gemfile bundle exec ruby /opt/${pkgname}/`basename "${f}"` \"\$@\"" > "${_msffile}"
+    echo -e "#!/bin/sh\nBUNDLE_GEMFILE=/opt/${pkgname}/Gemfile bundle-2.3 exec ruby-2.3 /opt/${pkgname}/`basename "${f}"` \"\$@\"" > "${_msffile}"
     chmod 755 "${_msffile}"
   done
 
   (cd "${pkgdir}/opt/${pkgname}"
     for f in tools/*/*.rb; do
       install -Dm 755 "${f}" ".${f}"
-      echo -e "#!/bin/sh\nBUNDLE_GEMFILE=/opt/${pkgname}/Gemfile bundle exec ruby /opt/${pkgname}/."${f}" \"\$@\"" > "${f}"
+      echo -e "#!/bin/sh\nBUNDLE_GEMFILE=/opt/${pkgname}/Gemfile bundle-2.3 exec ruby-2.3 /opt/${pkgname}/."${f}" \"\$@\"" > "${f}"
       chmod 755 "${f}"
     done
   )


### PR DESCRIPTION
Hello,
metasploit package is currently broken and outdated. This PR changes the dependency to ruby-2.3 and ruby2.3-bundler and updates it to version 4.13.15

Remarks are welcome