### PR TITLE
upgpkg: ropper 1.12.5

### DIFF
--- a/ropper/PKGBUILD
+++ b/ropper/PKGBUILD
@@ -3,7 +3,7 @@
 pkgbase=ropper
 pkgname=('ropper' 'python-ropper' 'python2-ropper')
 _pkgname=Ropper
-pkgver=1.11.11
+pkgver=1.12.5
 pkgrel=1
 pkgdesc='Show information about binary files and find gadgets to build rop chains for different architectures'
 url='https://github.com/sashs/Ropper'
@@ -12,7 +12,7 @@ license=('GPL2')
 makedepends=('python-setuptools' 'python-capstone' 'python-filebytes'
              'python2-setuptools' 'python2-capstone' 'python2-filebytes')
 source=(${pkgname}-${pkgver}.tar.gz::https://github.com/sashs/${_pkgname}/archive/v${pkgver}.tar.gz)
-sha512sums=('eb02c46e9f6f59d92e3515605fb425656d0e276be7a9bf795fb644a845a75f3504d2712f7995d7a91e10b39bcebc3649d3e7d37d2133b00fad3f9bfe70a31326')
+sha512sums=('d5afe158e16569a8bd7ec634f0666a8af2f057a72d0a0d0b974b72b3e44a7f826ebaa46b83a0c2c7bcc2a52b660f2f7cc94ecc54562be08d06079cb57e16ca41')
 
 prepare() {
   cp -ra ${_pkgname}-${pkgver}{,-py2}


### PR DESCRIPTION
ropper version in community repository is 1.11.11-1, that is from december 2018.

if there's anything else that needs to be changed, please let me know.