### PR TITLE
upgpkg: fish 3.1.0-1

### DIFF
--- a/fish/.SRCINFO
+++ b/fish/.SRCINFO
@@ -1,25 +1,27 @@
 pkgbase = fish
 	pkgdesc = Smart and user friendly shell intended mostly for interactive use
-	pkgver = 3.0.2
-	pkgrel = 3
+	pkgver = 3.1.0
+	pkgrel = 1
 	url = https://fishshell.com/
 	install = fish.install
 	arch = x86_64
 	license = GPL2
-	makedepends = doxygen
+	checkdepends = expect
+	makedepends = cmake
+	makedepends = python-sphinx
 	depends = glibc
 	depends = gcc-libs
-	depends = jq
 	depends = ncurses
 	depends = pcre2
 	optdepends = python: man page completion parser / web config tool
 	optdepends = pkgfile: command-not-found hook
-	source = https://github.com/fish-shell/fish-shell/archive/3.0.2/fish-3.0.2.tar.gz
-	source = fish-fix-systemd-version.patch::https://github.com/fish-shell/fish-shell/commit/c6ec4235136e82c709e8d7b455f7c463f9714b48.patch
-	sha256sums = 0421a3fdf5df54c14cddd4d764bc0931bbb4d37fb799205a9457c6eaba513166
-	sha256sums = b74077f1ae695ec4cd31acc8e1d4140ed2323716e1d0fac1cc2c66d06329431a
-	sha512sums = d3a24f85d4ada891ec4f6b14733edb236ae67f34868b0c9115fa5ebae99202a747ee9aeec7c6b04702f9a608019d5964b9cdc9abc4e3edfd7aaa9335093d8881
-	sha512sums = f4762c4fc6fcff7c52a9d10aa9b32d3470e0f5cee222927e2beccd0bb7fccf27fb628b33a9db7971362c38e53c2452f5cca513495bd6227e6b140afbd186217e
+	source = https://github.com/fish-shell/fish-shell/releases/download/3.1.0/fish-3.1.0.tar.gz
+	source = https://github.com/fish-shell/fish-shell/releases/download/3.1.0/fish-3.1.0.tar.gz.asc
+	validpgpkeys = 003837986104878835FA516D7A67D962D88A709A
+	sha256sums = e5db1e6839685c56f172e1000c138e290add4aa521f187df4cd79d4eab294368
+	sha256sums = SKIP
+	sha512sums = 143e462b5329790fa9834e135109e1397c3525756a0209d0ec68a53f7d2a1f581cd45fbbdcde6a5b53dff447da18ed6a62277993d851e7b18ef7f1a6b6d49cff
+	sha512sums = SKIP
 
 pkgname = fish
 

--- a/fish/PKGBUILD
+++ b/fish/PKGBUILD
@@ -6,42 +6,42 @@
 # Contributor: Jan Fader <jan.fader@web.de>
 
 pkgname=fish
-pkgver=3.0.2
-pkgrel=3
+pkgver=3.1.0
+pkgrel=1
 pkgdesc='Smart and user friendly shell intended mostly for interactive use'
 url='https://fishshell.com/'
 arch=('x86_64')
 license=('GPL2')
-depends=('glibc' 'gcc-libs' 'jq' 'ncurses' 'pcre2')
+depends=('glibc' 'gcc-libs' 'ncurses' 'pcre2')
 optdepends=('python: man page completion parser / web config tool'
             'pkgfile: command-not-found hook')
-makedepends=('doxygen')
+makedepends=('cmake' 'python-sphinx')
+checkdepends=('expect')
 install=fish.install
-source=(https://github.com/fish-shell/fish-shell/archive/${pkgver}/${pkgname}-${pkgver}.tar.gz
-        fish-fix-systemd-version.patch::https://github.com/fish-shell/fish-shell/commit/c6ec4235136e82c709e8d7b455f7c463f9714b48.patch)
-sha256sums=('0421a3fdf5df54c14cddd4d764bc0931bbb4d37fb799205a9457c6eaba513166'
-            'b74077f1ae695ec4cd31acc8e1d4140ed2323716e1d0fac1cc2c66d06329431a')
-sha512sums=('d3a24f85d4ada891ec4f6b14733edb236ae67f34868b0c9115fa5ebae99202a747ee9aeec7c6b04702f9a608019d5964b9cdc9abc4e3edfd7aaa9335093d8881'
-            'f4762c4fc6fcff7c52a9d10aa9b32d3470e0f5cee222927e2beccd0bb7fccf27fb628b33a9db7971362c38e53c2452f5cca513495bd6227e6b140afbd186217e')
+source=(https://github.com/fish-shell/fish-shell/releases/download/${pkgver}/fish-${pkgver}.tar.gz{,.asc})
+sha256sums=('e5db1e6839685c56f172e1000c138e290add4aa521f187df4cd79d4eab294368'
+            'SKIP')
+sha512sums=('143e462b5329790fa9834e135109e1397c3525756a0209d0ec68a53f7d2a1f581cd45fbbdcde6a5b53dff447da18ed6a62277993d851e7b18ef7f1a6b6d49cff'
+            'SKIP')
 
-prepare() {
-  cd fish-shell-${pkgver}
-  patch -p1 < ../fish-fix-systemd-version.patch
-  echo ${pkgver} > version
-  autoreconf -fiv
-}
+validpgpkeys=('003837986104878835FA516D7A67D962D88A709A') # David Adam <zanchey@gmail.com>
 
 build() {
-  cd fish-shell-${pkgver}
-  ./configure \
-    --prefix=/usr \
-    --sysconfdir=/etc
-  make
+  cmake -S fish-${pkgver} \
+        -B build \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_INSTALL_SYSCONFDIR=/etc
+
+  cmake --build build
+}
+
+check() {
+  cmake --build build --target test
 }
 
 package() {
-  cd fish-shell-${pkgver}
-  make DESTDIR="${pkgdir}" install
+  cmake --build build --target install -- DESTDIR="${pkgdir}"
 }
 
 # vim: ts=2 sw=2 et:

--- a/fish/fish.install
+++ b/fish/fish.install
@@ -1,6 +1,6 @@
 post_install() {
-  grep -qe '^/usr/bin/fish$' etc/shells || echo '/usr/bin/fish' >> etc/shells
   grep -qe '^/bin/fish$' etc/shells || echo '/bin/fish' >> etc/shells
+  grep -qe '^/usr/bin/fish$' etc/shells || echo '/usr/bin/fish' >> etc/shells
 }
 
 post_upgrade() {


### PR DESCRIPTION
The `fish` package was updated and, according to the [release notes](https://github.com/fish-shell/fish-shell/releases/tag/3.1.0), the `jq` package is no longer required for `npm`, `bower` and `yarn` completions. `doxygen` is no longer used for documentation but `python-sphinx` is used instead to build both `man` pages and HTML documentation. Also, the project has completely switched to `cmake` as the build system and the `autotools` suite is no longer supported (i.e. it's no longer possible to build the code base with it).

The `systemd` patch appears to have been applied upstream so there's no need for it anymore in the `PKGBUILD`. The `PKGBUILD` was also augmented with the `check()` function and the project's maintainer's PGP key.