### PR TITLE
Update for Gajim 1.3.1

### DIFF
--- a/gajim/PKGBUILD
+++ b/gajim/PKGBUILD
@@ -2,10 +2,10 @@
 # Contributor: Eric Bélanger <eric@archlinux.org>
 
 pkgname=gajim
-pkgver=1.2.2
-pkgrel=2
+pkgver=1.3.1
+pkgrel=1
 pkgdesc='Full featured and easy to use XMPP (Jabber) client'
-url='https://www.gajim.org/'
+url='https://gajim.org/'
 arch=('any')
 license=('GPL3')
 depends=('gtk3' 'python-cairo' 'python-gobject' 'python-keyring' 'python-nbxmpp'
@@ -33,8 +33,8 @@ optdepends=('alsa-utils: play notification sounds'
             'python-pillow: support of WebP avatars'
             'python-axolotl: OMEMO support'
             'python-qrcode: generate QR codes for OMEMO keys')
-source=(https://www.gajim.org/downloads/${pkgver%.*}/gajim-${pkgver}.tar.gz)
-sha512sums=('297afa2b0ac44aad59b203907b1479fb8f004e2dc2a00681fa8034d76e4fb89ee3dcb4fb96011028382659bcb978cf214c396073d29b3dd0a7a711454915057b')
+source=(https://www.gajim.org/downloads/${pkgver%.*}/gajim-${pkgver}-2.tar.gz)
+sha512sums=('01d0e77e856935c7d388144fdc8c33271f41752a3544f713eb0ffe070bb7aee6fb3ae28aeddcda69298e405de21bc2ef004e8d7f4c59b3b09eb9366bbd6b0642')
 
 build() {
   cd ${pkgname}-${pkgver}


### PR DESCRIPTION
The directory name was corrected in the second source file gajim-1.3.1-2.tar.gz. There are no functional differences to gajim-1.3.1.tar.gz. The suffix should probably be removed for the next release again.
python-nbxmpp needs to be updated as well.